### PR TITLE
Get File Type from Magic Header

### DIFF
--- a/core/sys_resource.py
+++ b/core/sys_resource.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import fastapi
 import aiofiles
 import re
+import filetype
 import mimetypes
 from typing import Optional
 
@@ -25,7 +26,9 @@ def check_name(name: str) -> bool:
 
 
 def get_mime(file: Path) -> Optional[str]:
-    return mimetypes.guess_type(file.name)[0]
+    if (type := filetype.guess(file)) is None:
+        return mimetypes.guess_type(file.name)[0]
+    return type.mime
 
 
 async def read(file: Path) -> bytes:

--- a/core/sys_resource.py
+++ b/core/sys_resource.py
@@ -3,6 +3,7 @@ import fastapi
 import aiofiles
 import re
 import mimetypes
+from typing import Optional
 
 bucket_path = Path("__file__").parent.joinpath("bucket")
 
@@ -23,7 +24,7 @@ def check_name(name: str) -> bool:
     return not re.search(r'[\\\/\:\*\?\"\<\>\|]', name)
 
 
-def get_mime(file: Path) -> str:
+def get_mime(file: Path) -> Optional[str]:
     return mimetypes.guess_type(file.name)[0]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fastapi
 pydantic
 python-multipart
 uvicorn
+filetype


### PR DESCRIPTION
改为使用filetype.py模块来获取文件类型。mimetype内置模块用来兜底。

相比于依赖Apache Tika服务，要简单许多。